### PR TITLE
feat: support webpack 2.4 chunk name annotation for "async-import"

### DIFF
--- a/src/Loader.ts
+++ b/src/Loader.ts
@@ -45,7 +45,7 @@ export type  LoaderCodeGen = Function & (
   | ( (file: string, module: string, loaderOptions: RouterLoaderOptions, resourceOptions: RouteResourceOptions) => string )
   )
 
-const LOAD_CHILDREN_RE = /loadChildren[\s]*:[\s]*['|"].+?['|"]/;
+const LOAD_CHILDREN_RE = /loadChildren[\s]*:[\s]*['|"].*#{1}.*['|"]/;
 
 export class Loader {
   public query: RouterLoaderOptions;

--- a/src/builtin_codegens.ts
+++ b/src/builtin_codegens.ts
@@ -43,9 +43,11 @@ systemCodeGen['deprecated'] = () => {
   systemCodeGen['deprecated'] = () => {};
 };
 
-export const importCodeGen: LoaderCodeGen = (file: string, module: string, opts: RouterLoaderOptions) => {
+export const importCodeGen: LoaderCodeGen = (file: string, module: string, opts: RouterLoaderOptions, resourceOptions: RouteResourceOptions) => {
+  const webpackChunkName = resourceOptions.chunkName ? ` /* webpackChunkName: "${resourceOptions.chunkName}" */` : '';  
+
   const result = [
-    `function importCodeGen() { return import_('${file}')`,
+    `function importCodeGen() { return import_('${file}'${webpackChunkName})`,
     `  .then( function(module) { return module['${module}']; } ); }`
   ];
 

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -419,6 +419,17 @@ describe('Loader', () => {
         });
     });
 
+    it('should output async-import codegen with chunk name', () => {
+      const loader = factory
+        .setOption('loader', 'async-import')
+        .toLoader();
+
+      return loader.replace(genCode('app/module-container/child-module#ChildModule?chunkName=foo'))
+        .then(mapToZero)
+        .then( (result: ReplaceResult) => {
+          expect(result.replacement).to.eql(`function() { return import('${cwdJoin('src/app/module-container/child-module/index')}' /* webpackChunkName: "foo" */)  .then( function(module) { return module['ChildModule']; } ); }`);
+        });
+    });
 
     it('should output a custom codegen', () => {
       const loader = factory.toLoader();


### PR DESCRIPTION
Since [version 2.4](https://github.com/webpack/webpack/releases/tag/v2.4.0) Webpack supports annotating `import()` calls with the name of the chunk:

```js
import(/* webpackChunkName: "my-chunk-name" */ "module")
```
This pull request adds the implementation of adding that annotation comment if the "chunkName" option is provided as part of the route, like so:
```ts
loadChildren: 'app/module-container/child-module#ChildModule?chunkName=my-chunk-name'
```