### PR TITLE
fix: false positive "loadChildren" regular expression match

### DIFF
--- a/src/Loader.ts
+++ b/src/Loader.ts
@@ -45,7 +45,7 @@ export type  LoaderCodeGen = Function & (
   | ( (file: string, module: string, loaderOptions: RouterLoaderOptions, resourceOptions: RouteResourceOptions) => string )
   )
 
-const LOAD_CHILDREN_RE = /loadChildren[\s]*:[\s]*['|"].+?['|"]/;
+const LOAD_CHILDREN_RE = /loadChildren[\s]*:[\s]*['|"].*#{1}.*['|"]/;
 
 export class Loader {
   public query: RouterLoaderOptions;


### PR DESCRIPTION
Fixes https://github.com/shlomiassaf/ng-router-loader/issues/11